### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "./dist/reef.cjs.min.js",
 	"module": "./dist/reef.es.min.js",
 	"browser": {
-		"reef-es": "./dist/reef.cjs.min.js",
+		"reef-es": "./dist/reef.es.min.js",
 		"reef-iife": "./dist/reef.min.js"
 	},
 	"author": {


### PR DESCRIPTION
The `browser["reef-es"]` property was set to `"./dist/reef.cjs.min.js"`. It should be `"./dist/reef.es.min.js"`.