### PR TITLE
Fix router concat

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -563,13 +563,11 @@ Reef.Router = function (options) {
 Reef.Router.prototype.addRoutes = function (routes) {
 	var type = Reef._.trueTypeOf(routes);
 	if (['array', 'object'].indexOf(type) < 0) return Reef._.err('Please provide a valid route or routes.');
-	var _routes = this.routes;
 	if (type === 'object') {
-		_routes.push(routes);
+		this.routes.push(routes);
 	} else {
-		_routes.concat(routes);
+		this.routes.push.apply(this.routes, routes);
 	}
-	this._routes = _routes;
 };
 
 /**


### PR DESCRIPTION
The Array.concat method creates a new array so `_routes.concat(routes);` do nothing. We could you `this.routes = _routes.concat(routes);` but `routes` is readonly. `push.apply` works better in this case.

Partially fixes #80

Test case can be found on https://codepen.io/ecanuto/pen/gOweLxZ

A future PR will fix _current since it must be calculated after constructor.